### PR TITLE
include plugin_management bash files in install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "brainscore_core"
 version = "0.1.0"
 description = ""
 authors = []
-license = {'file'='LICENSE'}
+license = { 'file' = 'LICENSE' }
 readme = "README.md"
 requires-python = ">=3.7"
 
@@ -28,3 +28,12 @@ requires = [
     "setuptools>=65.*",
     "wheel"
 ]
+
+
+################################################################
+#### setuptools packaging config ####
+################################################################
+
+[tool.setuptools.package-data]
+# include bash files (e.g. 'test_plugin.sh') in package install
+"brainscore_core.plugin_management" = ["**"]


### PR DESCRIPTION
otherwise domain libraries cannot access shell scripts such as `test_plugin.sh` (https://app.travis-ci.com/github/brain-score/language/jobs/589505636)