### PR TITLE
Flag Travis build for any plugin with non-zero return code - except 5 (I/O)! - from tests 

### DIFF
--- a/brainscore_core/plugin_management/test_plugins.py
+++ b/brainscore_core/plugin_management/test_plugins.py
@@ -97,6 +97,6 @@ def run_args(root_directory: Union[Path, str], test_file: Union[None, str] = Non
     else:
         warnings.warn("Test file not found.")
 
-    plugins_with_errors = {k: v for k, v in results.items() if v != 0}
+    plugins_with_errors = {k: v for k, v in results.items() if (v != 0) and (v != 5)}
     num_plugins_failed = len(plugins_with_errors)
     assert num_plugins_failed == 0, f"\n{num_plugins_failed} plugin tests failed\n{plugins_with_errors}"

--- a/brainscore_core/plugin_management/test_plugins.py
+++ b/brainscore_core/plugin_management/test_plugins.py
@@ -97,6 +97,6 @@ def run_args(root_directory: Union[Path, str], test_file: Union[None, str] = Non
     else:
         warnings.warn("Test file not found.")
 
-    plugins_with_errors = {k: v for k, v in results.items() if v == 1}
+    plugins_with_errors = {k: v for k, v in results.items() if v != 0}
     num_plugins_failed = len(plugins_with_errors)
     assert num_plugins_failed == 0, f"\n{num_plugins_failed} plugin tests failed\n{plugins_with_errors}"


### PR DESCRIPTION
Plugins that exempt themselves from any `pytest` testing (e.g. for memory-intensive testing) return with 5 instead of 0. This is a quick fix to prevent builds from failing while a more robust solution is implemented.