### PR TITLE
Prevent infinite `conda` scoring loops

### DIFF
--- a/brainscore_core/plugin_management/conda_score.py
+++ b/brainscore_core/plugin_management/conda_score.py
@@ -64,7 +64,7 @@ class CondaScore(EnvironmentManager):
 
 
 def wrap_score(library_path: Union[str, Path], model_identifier: str, benchmark_identifier: str,
-               score_function: Callable[[str, str], Score]):
+               score_function: Callable[[str, str], Score], conda_active: bool):
     """
     If :meth:`~brainscore_core.plugin_management.import_plugin.installation_preference` is not `newenv`,
     simply run the `score_function` and return its result directly.
@@ -80,7 +80,7 @@ def wrap_score(library_path: Union[str, Path], model_identifier: str, benchmark_
         and call :meth:`~brainscore_core.plugin_management.conda_score.CondaScore.save_score`,
         preferably via :meth:`~brainscore_core.plugin_management.conda_score.wrap_score`.
     """
-    if installation_preference() == 'newenv':
+    if installation_preference() == 'newenv' and not conda_active:
         conda_score = CondaScore(Path(library_path), model_identifier, benchmark_identifier)
         result = conda_score()
     else:


### PR DESCRIPTION
In conjunction with brain-score/language [PR #140](https://github.com/brain-score/language/pull/140), prevents infinite loops invoked during `conda` scoring runs. 