### PR TITLE
YAML Additions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ install:
 jobs:
   include:
     - stage: pr
+      script:
+        - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
       if: type = pull_request
-      script: pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
   
     - stage: branch
+      script:
+        - pytest -m "not pr_only and not requires_gpu and not memory_intense and not slow and not travis_slow"
       if: type = push
-      script: pytest -m "not pr_only and not requires_gpu and not memory_intense and not slow and not travis_slow"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: python
-python:
-  - "3.7"
-  - "3.8"
-  - "3.9"
 before_install:
   - pip install poetry
 install:
@@ -18,12 +14,40 @@ install:
   - pip list
 jobs:
   include:
-    - stage: pr
+    - stage: "PR Build"
+      name: "Python 3.7"
+      python: 3.7
+      script:
+        - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
+      if: type = pull_request
+    - stage: "PR Build"
+      name: "Python 3.8"
+      python: 3.8
+      script:
+        - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
+      if: type = pull_request
+    - stage: "PR Build"
+      name: "Python 3.9"
+      python: 3.9
       script:
         - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
       if: type = pull_request
   
-    - stage: branch
+    - stage: "Branch Build"
+      name: "Python 3.7"
+      python: 3.7
+      script:
+        - pytest -m "not pr_only and not requires_gpu and not memory_intense and not slow and not travis_slow"
+      if: type = push
+    - stage: "Branch Build"
+      name: "Python 3.8"
+      python: 3.8
+      script:
+        - pytest -m "not pr_only and not requires_gpu and not memory_intense and not slow and not travis_slow"
+      if: type = push
+    - stage: "Branch Build"
+      name: "Python 3.9"
+      python: 3.9
       script:
         - pytest -m "not pr_only and not requires_gpu and not memory_intense and not slow and not travis_slow"
       if: type = push


### PR DESCRIPTION
https://github.com/brain-score/core/blob/kvf/reduce-language-test-time/.travis.yml#L2-L5 triggers 3 builds for mentioned python versions in addition to the job.include buildsl, without any script tag within the root of the YAML config which results in https://app.travis-ci.com/github/brain-score/core/jobs/607420814#L634.

This PR explicitly defines the jobs within job.include phases with the required python versions.