### PR TITLE
Modified endpoint to separate getting models/benchmarks from scoring

### DIFF
--- a/brainscore_core/plugin_management/conda_score.sh
+++ b/brainscore_core/plugin_management/conda_score.sh
@@ -10,7 +10,7 @@ ENVS_DIR=$6
 ### DEPENDENCIES
 
 get_plugin_dir() {
-  python brainscore_core/plugin_management/import_plugin print_plugin_dir "$LIBRARY_NAME" "$1" "$2"
+  python -m brainscore_core.plugin_management.import_plugin print_plugin_dir "$LIBRARY_NAME" "$1" "$2"
 }
 
 MODEL_DIR=$LIBRARY_NAME/models/$(get_plugin_dir "models" "$MODEL_ID")
@@ -36,7 +36,7 @@ if [ -f "$BENCHMARK_ENV_YML" ]; then
   output=$(conda env update --file $BENCHMARK_ENV_YML 2>&1) || echo $output
 fi
 # install library dependencies
-output=$(python -m pip install "." 2>&1) || echo $output
+output=$(python -m pip install -e "." 2>&1) || echo $output
 
 ### SCORING
 echo "Scoring ${MODEL_ID} on ${BENCHMARK_ID}"

--- a/brainscore_core/submission/endpoints.py
+++ b/brainscore_core/submission/endpoints.py
@@ -254,7 +254,7 @@ def make_argparser() -> ArgumentParser:
                         help='ID of submitting user in the postgres DB')
     parser.add_argument('--author_email', type=str, nargs='?', default=None,
                         help='email associated with PR author GitHub username')
-    parser.add_argument('--specified_only', type=bool, nargs='?', default=False,
+    parser.add_argument('--specified_only', default=False, action="store_true",
                         help='Only score the plugins specified by new_models and new_benchmarks')
     parser.add_argument('--new_models', type=str, nargs='*', default=None,
                         help='The identifiers of newly submitted models to score on all benchmarks')

--- a/brainscore_core/submission/endpoints.py
+++ b/brainscore_core/submission/endpoints.py
@@ -148,30 +148,6 @@ class RunScoringEndpoint:
         logger.info(f'Submission is stored as {submission_status}')
         submission_entry.save()
 
-    def resolve_models(self, domain: str, models: List[str]) -> List[str]:
-        """
-        Identify the set of models by resolving `models` to the list of public models if `models` is `ALL_PUBLIC`
-
-        :param domain: "language" or "vision"
-        :param models: either a list of model identifiers or the string
-            :attr:`~brainscore_core.submission.endpoints.RunScoringEndpoint.ALL_PUBLIC` to select all public models
-        """
-        if models == self.ALL_PUBLIC:
-            models = public_model_identifiers(domain)
-        return models
-    
-    def resolve_benchmarks(self, domain: str, benchmarks: List[str]) -> List[str]:
-        """
-        Identify the set of benchmarks by resolving `benchmarks` to the list of public models if `benchmarks` is `ALL_PUBLIC`
-
-        :param domain: "language" or "vision"
-        :param benchmarks: either a list of benchmark identifiers or the string
-            :attr:`~brainscore_core.submission.endpoints.RunScoringEndpoint.ALL_PUBLIC` to select all public benchmarks
-        """
-        if benchmarks == self.ALL_PUBLIC:
-            benchmarks = public_benchmark_identifiers(domain)
-        return benchmarks
-
     def _score_model_on_benchmark(self, model_identifier: str, benchmark_identifier: str,
                                   submission_entry: database_models.Submission, domain: str,
                                   public: bool, competition: Union[None, str]):

--- a/brainscore_core/submission/endpoints.py
+++ b/brainscore_core/submission/endpoints.py
@@ -142,7 +142,7 @@ class RunScoringEndpoint:
 
         # finalize status of submission
         submission_status = 'successful' if is_run_successful else 'failure'
-        if getattr(submission_entry, 'status', "successful") is not 'failure':
+        if getattr(submission_entry, 'status', "successful") != 'failure':
             submission_entry.status = submission_status
         logger.info(f'Submission is stored as {submission_status}')
         submission_entry.save()

--- a/brainscore_core/submission/endpoints.py
+++ b/brainscore_core/submission/endpoints.py
@@ -116,16 +116,14 @@ class RunScoringEndpoint:
     def __call__(self, domain: str, jenkins_id: int, model_identifier: str, benchmark_identifier: str,
                  user_id: int, model_type: str, public: bool, competition: Union[None, str]):
         """
-        Run the `models` on the `benchmarks`, and write resulting score to the database.
+        Run the `model_identifier` on the `benchmark_identifier`, and write resulting score to the database.
 
         Explanation of subset of parameters:
         :param domain: "language" or "vision"
-        :param models: either a list of model identifiers or the string
-            :attr:`~brainscore_core.submission.endpoints.RunScoringEndpoint.ALL_PUBLIC` to select all public models
-        :param benchmarks: either a list of benchmark identifiers or the string
-            :attr:`~brainscore_core.submission.endpoints.RunScoringEndpoint.ALL_PUBLIC` to select all public benchmarks
+        :param model_identifier: a string of a model identifier
+        :param benchmark_identifier: a string of a model identifier
         """
-        # setup entry for this entire submission
+        # setup entry for this submission
         submission_entry = submissionentry_from_meta(jenkins_id=jenkins_id, user_id=user_id, model_type=model_type)
         entire_submission_successful = True
 

--- a/brainscore_core/submission/endpoints.py
+++ b/brainscore_core/submission/endpoints.py
@@ -125,9 +125,8 @@ class RunScoringEndpoint:
         """
         # setup entry for this submission
         submission_entry = submissionentry_from_meta(jenkins_id=jenkins_id, user_id=user_id, model_type=model_type)
-        entire_submission_successful = True
-
-
+        is_run_successful = True
+        
         logger.debug(f"Scoring {model_identifier} on {benchmark_identifier}")
 
         try:
@@ -136,13 +135,13 @@ class RunScoringEndpoint:
                                             submission_entry=submission_entry, domain=domain,
                                             public=public, competition=competition)
         except Exception as e:
-            entire_submission_successful = False
+            is_run_successful = False
             logging.error(
                 f'Could not run model {model_identifier} on benchmark {benchmark_identifier} because of {e}',
                 exc_info=True)
 
         # finalize status of submission
-        submission_status = 'successful' if entire_submission_successful else 'failure'
+        submission_status = 'successful' if is_run_successful else 'failure'
         if getattr(submission_entry, 'status', "successful") is not 'failure':
             submission_entry.status = submission_status
         logger.info(f'Submission is stored as {submission_status}')

--- a/brainscore_core/submission/endpoints.py
+++ b/brainscore_core/submission/endpoints.py
@@ -206,7 +206,7 @@ def resolve_models(domain: str, models: Union[List[str], str]) -> List[str]:
 
 def resolve_benchmarks(domain: str, benchmarks: Union[List[str], str]) -> List[str]:
     """
-    Identify the set of benchmarks by resolving `benchmarks` to the list of public models if `benchmarks` is `ALL_PUBLIC`
+    Identify the set of benchmarks by resolving `benchmarks` to the list of public benchmarks if `benchmarks` is `ALL_PUBLIC`
     :param domain: "language" or "vision"
     :param benchmarks: either a list of benchmark identifiers or the string
         :attr:`~brainscore_core.submission.endpoints.RunScoringEndpoint.ALL_PUBLIC` to select all public benchmarks
@@ -214,6 +214,23 @@ def resolve_benchmarks(domain: str, benchmarks: Union[List[str], str]) -> List[s
     if benchmarks == RunScoringEndpoint.ALL_PUBLIC:
         benchmarks = public_benchmark_identifiers(domain)
     return benchmarks
+
+def resolve_models_benchmarks(domain: str, args_dict: Dict[str, Union[str, List]]):
+    """
+    Identify the set of model/benchmark pairs to score by resolving `new_models` and `new_benchmarks` in the user input.
+    Prints the names of models and benchmarks to stdout.
+    :param domain: "language" or "vision"
+    :param args_dict: a map containing `new_models`, `new_benchmarks`, and `specified_only`, specifying which the
+        model/benchmark names to be resolved.
+    """
+    benchmarks, models = retrieve_models_and_benchmarks(args_dict)
+    
+    benchmark_ids = resolve_benchmarks(domain=domain, benchmarks=benchmarks)
+    model_ids = resolve_models(domain=domain, models=models)
+
+    print("BS_NEW_MODELS=" + " ".join(model_ids))
+    print("BS_NEW_BENCHMARKS=" + " ".join(benchmark_ids))
+    return model_ids, benchmark_ids
 
 def shorten_text(text: str, max_length: int) -> str:
     if len(text) <= max_length:

--- a/brainscore_core/submission/endpoints.py
+++ b/brainscore_core/submission/endpoints.py
@@ -193,6 +193,27 @@ class RunScoringEndpoint:
             score_entry.save()
             raise e
 
+def resolve_models(domain: str, models: Union[List[str], str]) -> List[str]:
+    """
+    Identify the set of models by resolving `models` to the list of public models if `models` is `ALL_PUBLIC`
+    :param domain: "language" or "vision"
+    :param models: either a list of model identifiers or the string
+        :attr:`~brainscore_core.submission.endpoints.RunScoringEndpoint.ALL_PUBLIC` to select all public models
+    """
+    if models == RunScoringEndpoint.ALL_PUBLIC:
+        models = public_model_identifiers(domain)
+    return models
+
+def resolve_benchmarks(domain: str, benchmarks: Union[List[str], str]) -> List[str]:
+    """
+    Identify the set of benchmarks by resolving `benchmarks` to the list of public models if `benchmarks` is `ALL_PUBLIC`
+    :param domain: "language" or "vision"
+    :param benchmarks: either a list of benchmark identifiers or the string
+        :attr:`~brainscore_core.submission.endpoints.RunScoringEndpoint.ALL_PUBLIC` to select all public benchmarks
+    """
+    if benchmarks == RunScoringEndpoint.ALL_PUBLIC:
+        benchmarks = public_benchmark_identifiers(domain)
+    return benchmarks
 
 def shorten_text(text: str, max_length: int) -> str:
     if len(text) <= max_length:

--- a/brainscore_core/submission/endpoints.py
+++ b/brainscore_core/submission/endpoints.py
@@ -243,6 +243,9 @@ def make_argparser() -> ArgumentParser:
                         help='The identifiers of newly submitted models to score on all benchmarks')
     parser.add_argument('--new_benchmarks', type=str, nargs='*', default=None,
                         help='The identifiers of newly submitted benchmarks on which to score all models')
+    parser.add_argument('--fn', type=str, nargs='?', default='run_scoring',
+                    choices=['run_scoring', 'resolve_models_benchmarks'],
+                    help='The endpoint method to run. `run_scoring` to score `new_models` on `new_benchmarks`, or `resolve_models_benchmarks` to respond with a list of models and benchmarks to score.')
     return parser
 
 

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -8,7 +8,7 @@ import requests
 from brainscore_core import Score, Benchmark
 from brainscore_core.submission import database_models
 from brainscore_core.submission.database import connect_db
-from brainscore_core.submission.endpoints import RunScoringEndpoint, DomainPlugins, UserManager, shorten_text, resolve_models, resolve_benchmarks
+from brainscore_core.submission.endpoints import RunScoringEndpoint, DomainPlugins, UserManager, shorten_text, resolve_models_benchmarks, resolve_models, resolve_benchmarks
 from brainscore_core.submission.database_models import Model, BenchmarkType, clear_schema
 from tests.test_submission import init_users
 
@@ -147,6 +147,16 @@ class TestRunScoring:
         endpoint_benchmarks = resolve_benchmarks(domain=domain, benchmarks=benchmarks)
         assert endpoint_models == ["dummymodel1", "dummymodel2"]
         assert endpoint_benchmarks == ['dummybenchmark1', 'dummybenchmark2']
+
+    def test_resolve_models_and_benchmarks(self):
+        domain, new_models, new_benchmarks = 'test', ['dummymodel1'], ['dummybenchmark1']
+        args_dict = {'jenkins_id': 62, 'user_id': 1, 'model_type': 'artificialsubject', 
+                    'public': True, 'competition': 'None', 'new_models': new_models, 
+                    'new_benchmarks': new_benchmarks, 'specified_only': True}
+        model_ids, benchmark_ids = resolve_models_benchmarks(domain=domain, args_dict=args_dict)
+        
+        assert model_ids == new_models
+        assert benchmark_ids == new_benchmarks
     
     def test_score_model_benchmark(self):
         domain, model_id, benchmark_id = 'test', 'dummymodel1', 'dummybenchmark1'

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -107,7 +107,7 @@ class TestRunScoring:
         init_users()
         
         for model_id in ["dummymodel1", "dummymodel2"]:
-            Model.get_or_create(name=model_id, domain="test", public=True, owner=2)
+            Model.get_or_create(name=model_id, domain="test", public=True, owner=2, submission=0)
         for benchmark_id in ["dummybenchmark1", "dummybenchmark2"]:
             BenchmarkType.get_or_create(identifier=benchmark_id, domain="test", visible=True, order=999)
 

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -97,6 +97,7 @@ class TestRunScoring:
         try:
             connect_db(db_secret=POSTGRESQL_TEST_DATABASE)
             cls.test_database = POSTGRESQL_TEST_DATABASE
+            raise botocore.exceptions.NoCredentialsError
         except botocore.exceptions.NoCredentialsError:  # we're in an environment where we cannot retrieve AWS secrets
             connect_db(db_secret='sqlite3.db')
             cls.test_database = 'sqlite3.db'  # -> use local sqlite database
@@ -119,7 +120,8 @@ class TestRunScoring:
         domain, models, benchmarks = 'test', ['dummymodel1'], ['dummybenchmark1']
         endpoint = RunScoringEndpoint(domain_plugins=DummyDomainPlugins(), db_secret=self.test_database)
         
-        endpoint_models, endpoint_benchmarks = endpoint.get_models_and_benchmarks_to_score(domain=domain, models=models, benchmarks=benchmarks)
+        endpoint_models = endpoint.resolve_models(domain=domain, models=models)
+        endpoint_benchmarks = endpoint.resolve_benchmarks(domain=domain, benchmarks=benchmarks)
         assert endpoint_models == models
         assert endpoint_benchmarks == benchmarks
 
@@ -127,7 +129,8 @@ class TestRunScoring:
         domain, models, benchmarks = 'test', RunScoringEndpoint.ALL_PUBLIC, ['dummybenchmark1']
         endpoint = RunScoringEndpoint(domain_plugins=DummyDomainPlugins(), db_secret=self.test_database)
         
-        endpoint_models, endpoint_benchmarks = endpoint.get_models_and_benchmarks_to_score(domain=domain, models=models, benchmarks=benchmarks)
+        endpoint_models = endpoint.resolve_models(domain=domain, models=models)
+        endpoint_benchmarks = endpoint.resolve_benchmarks(domain=domain, benchmarks=benchmarks)
         assert endpoint_models == ["dummymodel1", "dummymodel2"]
         assert endpoint_benchmarks == benchmarks
 
@@ -135,7 +138,8 @@ class TestRunScoring:
         domain, models, benchmarks = 'test', ['dummymodel1'], RunScoringEndpoint.ALL_PUBLIC
         endpoint = RunScoringEndpoint(domain_plugins=DummyDomainPlugins(), db_secret=self.test_database)
         
-        endpoint_models, endpoint_benchmarks = endpoint.get_models_and_benchmarks_to_score(domain=domain, models=models, benchmarks=benchmarks)
+        endpoint_models = endpoint.resolve_models(domain=domain, models=models)
+        endpoint_benchmarks = endpoint.resolve_benchmarks(domain=domain, benchmarks=benchmarks)
         assert endpoint_models == models
         assert endpoint_benchmarks == ['dummybenchmark1', 'dummybenchmark2']
 
@@ -143,7 +147,8 @@ class TestRunScoring:
         domain, models, benchmarks = 'test', RunScoringEndpoint.ALL_PUBLIC, RunScoringEndpoint.ALL_PUBLIC
         endpoint = RunScoringEndpoint(domain_plugins=DummyDomainPlugins(), db_secret=self.test_database)
         
-        endpoint_models, endpoint_benchmarks = endpoint.get_models_and_benchmarks_to_score(domain=domain, models=models, benchmarks=benchmarks)
+        endpoint_models = endpoint.resolve_models(domain=domain, models=models)
+        endpoint_benchmarks = endpoint.resolve_benchmarks(domain=domain, benchmarks=benchmarks)
         assert endpoint_models == ["dummymodel1", "dummymodel2"]
         assert endpoint_benchmarks == ['dummybenchmark1', 'dummybenchmark2']
     
@@ -163,7 +168,8 @@ class TestRunScoring:
         domain, models, benchmarks = 'test', ['dummymodel1'], RunScoringEndpoint.ALL_PUBLIC
         endpoint = RunScoringEndpoint(domain_plugins=DummyDomainPlugins(), db_secret=self.test_database)
         
-        models, benchmarks = endpoint.get_models_and_benchmarks_to_score(domain=domain, models=models, benchmarks=benchmarks)
+        models = endpoint.resolve_models(domain=domain, models=models)
+        benchmarks = endpoint.resolve_benchmarks(domain=domain, benchmarks=benchmarks)
 
         for model_id in models:
             for benchmark_id in benchmarks:


### PR DESCRIPTION
### Description
This PR is motivated by the need to run individual scoring jobs for each model/benchmark pair on an HPC (e.g. Openmind) instead of running a single job to compute scores for all new models and benchmarks in a submission. We handle this by changing the structure of the scoring endpoint to separate getting the model/benchmark names functionality from the actual scoring (for example, to evaluate `ALL_PUBLIC` without necessarily scoring). As a result, the domain-specific plugin manager now has the flexibility to decide the best method for identifying and scoring the model/benchmark pairs.

### Testing Strategy
This PR implements unit tests that separately test the functionality of both model/benchmark retrieval and scoring using dummy models and benchmarks.
