### PR TITLE
Add `build.os` to `readthedocs.yml`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,10 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+   python: "3.8"
+
 python:
-   version: 3.8
    install:
       - requirements: docs/requirements.txt


### PR DESCRIPTION
Adds build.os config key [in compliance with Read the Docs v2.0](https://blog.readthedocs.com/use-build-os-config/).