### PR TITLE
Fixed an I/O bug where 'get_scoring_info' would generate a non-JSON serializable string

### DIFF
--- a/brainscore_core/plugin_management/parse_plugin_changes.py
+++ b/brainscore_core/plugin_management/parse_plugin_changes.py
@@ -1,6 +1,7 @@
 import re
 import subprocess
 import sys
+import json
 from pathlib import Path
 from typing import List, Tuple, Dict
 
@@ -107,7 +108,8 @@ def get_scoring_info(changed_files: str, domain_root: str):
 	else:
 		plugin_info_dict["run_score"] = "False"
 
-	print(plugin_info_dict) # output is accessed via print!
+	plugin_info_json = json.dumps(plugin_info_dict)
+	print(plugin_info_json) # output is accessed via print!
 
 
 def get_testing_info(changed_files: str, domain_root: str):

--- a/tests/test_plugin_management/test_parse_plugin_changes.py
+++ b/tests/test_plugin_management/test_parse_plugin_changes.py
@@ -1,4 +1,4 @@
-import ast
+import json
 import contextlib
 import io
 from pathlib import Path
@@ -86,7 +86,7 @@ def test_get_scoring_info_scoring_needed(mocker):
     f = io.StringIO()
     with contextlib.redirect_stdout(f):
         get_scoring_info(changed_files, 'brainscore_core')
-    plugin_info_dict = ast.literal_eval(f.getvalue())
+    plugin_info_dict = json.loads(f.getvalue())
     print(plugin_info_dict)
 
     assert plugin_info_dict["run_score"] == str(True)
@@ -99,7 +99,7 @@ def test_get_scoring_info_scoring_not_needed():
     f = io.StringIO()
     with contextlib.redirect_stdout(f):
         get_scoring_info(changed_files, 'brainscore_core')
-    plugin_info_dict = ast.literal_eval(f.getvalue())
+    plugin_info_dict = json.loads(f.getvalue())
     print(plugin_info_dict)
 
     assert plugin_info_dict["run_score"] == str(False)


### PR DESCRIPTION
This code fixes a bug where the output printed by `get_scoring_info` is not JSON-serializable. In particular, running a simple command like:
```bash
python -c 'from brainscore_core.plugin_management.parse_plugin_changes import get_scoring_info; get_scoring_info("brainscore_language/models/gpt/__init__.py ", "brainscore_language")'
```
prints:
```python
{'modifies_plugins': True, 'changed_plugins': {'models': ['gpt'], 'benchmarks': [], 'data': [], 'metrics': []}, 'is_automergeable': True, 'run_score': 'True', 'new_models': 'distilgpt2 gpt2 gpt2-medium gpt2-large gpt2-xl gpt-neo-2.7B gpt-neo-1.3B', 'new_benchmarks': ''}
```

This output doesn't follow JSON format, particularly because it uses single quotes `'` instead of double quotes `"`, and because it uses `True` and `False` instead of `true` and `false`. Therefore, attempting to parse it using, for example, `jq`, results in an error:

```bash
echo "{'modifies_plugins': True, 'changed_plugins': {'models': ['gpt'], 'benchmarks': [], 'data': [], 'metrics': []}, 'is_automergeable': True, 'run_score': 'True', 'new_models': 'distilgpt2 gpt2 gpt2-medium gpt2-large gpt2-xl gpt-neo-2.7B gpt-neo-1.3B', 'new_benchmarks': ''}" | jq .
```

results in:
```
parse error: Invalid numeric literal at line 1, column 20
```

This PR fixes this issue by ensuring that the output from `get_scoring_info` is JSON-serializable.

Additionally, since the primary use case of this method is communicating information with a JSON decoder, this PR updates the unit tests for `get_scoring_info` to use `json.loads` instead of `ast.literal_eval`.