### PR TITLE
Updated test plugin script to use current python version

### DIFF
--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -7,7 +7,7 @@ PLUGIN_TEST_PATH=$PLUGIN_PATH/test.py
 SINGLE_TEST=$3
 CONDA_ENV_PATH=$PLUGIN_PATH/environment.yml
 LIBRARY_PATH=$4
-PYTHON_VERSION=$(python -V | cut -d ' ' -f 2 | cut -d '.' -f 1,2)
+PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
 
 PYTEST_SETTINGS=${PYTEST_SETTINGS:-"not requires_gpu and not memory_intense and not slow"}
 

--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -7,6 +7,8 @@ PLUGIN_TEST_PATH=$PLUGIN_PATH/test.py
 SINGLE_TEST=$3
 CONDA_ENV_PATH=$PLUGIN_PATH/environment.yml
 LIBRARY_PATH=$4
+PYTHON_VERSION=$(python -V | cut -d ' ' -f 2 | cut -d '.' -f 1,2)
+
 PYTEST_SETTINGS=${PYTEST_SETTINGS:-"not requires_gpu and not memory_intense and not slow"}
 
 cd "$LIBRARY_PATH" || exit 2
@@ -15,7 +17,7 @@ echo "$PLUGIN_NAME ($PLUGIN_PATH)"
 ### DEPENDENCIES
 echo "Setting up conda environment..."
 eval "$(command conda 'shell.bash' 'hook' 2>/dev/null)"
-output=$(conda create -n $PLUGIN_NAME python=3.8 -y 2>&1) || echo $output
+output=$(conda create -n $PLUGIN_NAME python=$PYTHON_VERSION -y 2>&1) || echo $output
 conda activate $PLUGIN_NAME
 if [ -f "$CONDA_ENV_PATH" ]; then
   output=$(conda env update --file $CONDA_ENV_PATH 2>&1) || echo $output


### PR DESCRIPTION
This PR updates the `test_plugin.sh` to use the current version of Python when initializing the testing conda environments for each plugin. This accommodates the case where the domain-specific brain-score library uses a specific Python version (e.g. Brain-Score Vision requires Python 3.7, so 3.8 wouldn't work).