### PR TITLE
Don't log output from `conda` env installation

### DIFF
--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -24,7 +24,7 @@ if [ -f "$PLUGIN_REQUIREMENTS_PATH" ]; then
   output=$(pip install -r $PLUGIN_REQUIREMENTS_PATH 2>&1)
 fi
 
-output=$(python -m pip install -e ".[test]" 2>&1) || echo $output # install library requirements
+output=$(python -m pip install -e ".[test]" 2>&1) # install library requirements
 
 ### RUN TESTING
 if [ "$SINGLE_TEST" != False ]; then

--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -15,13 +15,13 @@ echo "$PLUGIN_NAME ($PLUGIN_PATH)"
 ### DEPENDENCIES
 echo "Setting up conda environment..."
 eval "$(command conda 'shell.bash' 'hook' 2>/dev/null)"
-output=$(conda create -n $PLUGIN_NAME python=3.8 -y 2>&1) || echo $output
+output=$(conda create -n $PLUGIN_NAME python=3.8 -y 2>&1)
 conda activate $PLUGIN_NAME
 if [ -f "$CONDA_ENV_PATH" ]; then
-  output=$(conda env update --file $CONDA_ENV_PATH 2>&1) || echo $output
+  output=$(conda env update --file $CONDA_ENV_PATH 2>&1)
 fi
 if [ -f "$PLUGIN_REQUIREMENTS_PATH" ]; then
-  output=$(pip install -r $PLUGIN_REQUIREMENTS_PATH 2>&1) || echo $output
+  output=$(pip install -r $PLUGIN_REQUIREMENTS_PATH 2>&1)
 fi
 
 output=$(python -m pip install -e ".[test]" 2>&1) || echo $output # install library requirements


### PR DESCRIPTION
Reduce test log size by not logging output from the `conda` env installation step in `test_plugin.sh`.

May help with Travis errors that appear to be correlated with large logs resulting in marking failed tests as passing. For example, see https://app.travis-ci.com/github/brain-score/brain-score/jobs/615240231