### PR TITLE
Use built-in variable to evaluate secrets access in Travis

### DIFF
--- a/brainscore_core/travis/script.yml
+++ b/brainscore_core/travis/script.yml
@@ -13,7 +13,7 @@ script:
       python -c "from brainscore_core.plugin_management.parse_plugin_changes import run_changed_plugin_tests; run_changed_plugin_tests(\"${CHANGED_FILES}\", \"brainscore_${DOMAIN}\")"; 
     fi
   - |
-    if [ "$PRIVATE_ACCESS" = 1 ] && [ -n "${GITHUB_TOKEN}" ] && [ "$PLUGIN_ONLY" = "False" ]; then 
+    if [ "$PRIVATE_ACCESS" = 1 ] && [ "${TRAVIS_SECURE_ENV_VARS}" = true ] && [ "$PLUGIN_ONLY" = "False" ]; then 
       pytest -m "private_access and $PYTEST_SETTINGS"; 
     fi
   - |

--- a/brainscore_core/travis/script.yml
+++ b/brainscore_core/travis/script.yml
@@ -13,7 +13,7 @@ script:
       python -c "from brainscore_core.plugin_management.parse_plugin_changes import run_changed_plugin_tests; run_changed_plugin_tests(\"${CHANGED_FILES}\", \"brainscore_${DOMAIN}\")"; 
     fi
   - |
-    if [ "$PRIVATE_ACCESS" = 1 ] && [ "${TRAVIS_SECURE_ENV_VARS}" = true ] && [ "$PLUGIN_ONLY" = "False" ]; then 
+    if [ "$PRIVATE_ACCESS" = 1 ] && [ "$TRAVIS_SECURE_ENV_VARS" = true ] && [ "$PLUGIN_ONLY" = "False" ]; then 
       pytest -m "private_access and $PYTEST_SETTINGS"; 
     fi
   - |


### PR DESCRIPTION
Use built-in variable `TRAVIS_SECURE_ENV_VARS` to assess if private tests can be run (requires access to secrets).