### PR TITLE
Update conda environment settings for testing and scoring

### DIFF
--- a/brainscore_core/plugin_management/conda_score.sh
+++ b/brainscore_core/plugin_management/conda_score.sh
@@ -28,6 +28,7 @@ echo "Setting up conda environment: ${ENV_NAME}"
 eval "$(command conda 'shell.bash' 'hook' 2>/dev/null)"
 output=$(conda create -n $ENV_NAME python=3.8 -y 2>&1) || echo $output
 conda activate $ENV_NAME
+conda install pip
 # install plugin yml environments if available
 if [ -f "$MODEL_ENV_YML" ]; then
   output=$(conda env update --file $MODEL_ENV_YML 2>&1) || echo $output

--- a/brainscore_core/plugin_management/conda_score.sh
+++ b/brainscore_core/plugin_management/conda_score.sh
@@ -8,6 +8,7 @@ ENV_NAME=$5
 ENVS_DIR=$6
 
 ### DEPENDENCIES
+PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')")
 
 get_plugin_dir() {
   python -m brainscore_core.plugin_management.import_plugin print_plugin_dir "$LIBRARY_NAME" "$1" "$2"
@@ -26,7 +27,7 @@ if [ -d $ENVS_DIR/$ENV_NAME ]; then
 fi
 echo "Setting up conda environment: ${ENV_NAME}"
 eval "$(command conda 'shell.bash' 'hook' 2>/dev/null)"
-output=$(conda create -n $ENV_NAME python=3.8 -y 2>&1) || echo $output
+output=$(conda create -n $ENV_NAME python=$PYTHON_VERSION -y 2>&1) || echo $output
 conda activate $ENV_NAME
 conda install pip
 # install plugin yml environments if available

--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -22,6 +22,7 @@ echo "Setting up conda environment..."
 eval "$(command conda 'shell.bash' 'hook' 2>/dev/null)"
 output=$(conda create -n $PLUGIN_NAME python=$PYTHON_VERSION -y 2>&1)
 conda activate $PLUGIN_NAME
+conda install pip
 if [ -f "$CONDA_ENV_PATH" ]; then
   output=$(conda env update --file $CONDA_ENV_PATH 2>&1)
 fi


### PR DESCRIPTION
* Install `pip` after activating `conda` environment
* `python` version was fixed to `3.8` when running scoring in a conda environment; now inherited from base.