### PR TITLE
Allow for in-memory sqlite endpoint testing

### DIFF
--- a/brainscore_core/submission/database.py
+++ b/brainscore_core/submission/database.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def connect_db(db_secret):
-    if 'sqlite3' not in db_secret:
+    if 'sqlite3' not in db_secret or ':memory:' not in db_secret:
         secret = get_secret(db_secret)
         db_configs = json.loads(secret)
         postgres = PostgresqlDatabase(db_configs['dbInstanceIdentifier'],

--- a/brainscore_core/submission/database.py
+++ b/brainscore_core/submission/database.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def connect_db(db_secret):
-    if 'sqlite3' not in db_secret or ':memory:' not in db_secret:
+    if 'sqlite3' not in db_secret and ':memory:' not in db_secret:
         secret = get_secret(db_secret)
         db_configs = json.loads(secret)
         postgres = PostgresqlDatabase(db_configs['dbInstanceIdentifier'],


### PR DESCRIPTION
Adds a check to see if the db_secret is ':memory:', which is a new testing feature added in [this PR](https://github.com/brain-score/vision/pull/520). This allows for multiple testing runs to progress without database collisions since each testing run will have a new database file in memory. 