### PR TITLE
New schema for each testing run

### DIFF
--- a/brainscore_core/submission/database.py
+++ b/brainscore_core/submission/database.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def connect_db(db_secret):
-    if 'sqlite3' not in db_secret and ':memory:' not in db_secret:
+    if 'sqlite3' not in db_secret:
         secret = get_secret(db_secret)
         db_configs = json.loads(secret)
         postgres = PostgresqlDatabase(db_configs['dbInstanceIdentifier'],

--- a/brainscore_core/submission/database_models.py
+++ b/brainscore_core/submission/database_models.py
@@ -126,7 +126,11 @@ def create_schema(schema_name):
     """
     Creates an isolated schema for testing purposes.
     """
-    database_proxy.execute_sql(f'CREATE SCHEMA IF NOT EXISTS {schema_name}')
+    try:
+        database_proxy.execute_sql(f'CREATE SCHEMA IF NOT EXISTS {schema_name}')
+        print(f"Schema {schema_name} created successfully.")
+    except Exception as e:
+        print(f"Error creating schema {schema_name}: {e}")
 
 def drop_schema(schema_name):
     """

--- a/brainscore_core/submission/database_models.py
+++ b/brainscore_core/submission/database_models.py
@@ -137,3 +137,10 @@ def drop_schema(schema_name):
     Drops a schema that was used for testing purposes.
     """
     database_proxy.execute_sql(f'DROP SCHEMA IF EXISTS {schema_name} CASCADE')
+
+def create_tables():
+    """
+    Creates the necessary tables for a test database schema.
+    """
+    with database_proxy:
+        database_proxy.create_tables(PeeweeBase.__subclasses__(), safe=True)

--- a/brainscore_core/submission/database_models.py
+++ b/brainscore_core/submission/database_models.py
@@ -5,9 +5,13 @@ database_proxy = Proxy()
 
 
 class PeeweeBase(PeeweeModel):
+    @classmethod
+    def set_schema(cls, schema_name):
+        for model in cls.__subclasses__():
+            model._meta.schema = schema_name
+    
     class Meta:
         database = database_proxy
-        schema = 'public'
 
 
 class Reference(PeeweeBase):
@@ -117,3 +121,15 @@ def clear_schema():
     BenchmarkType.delete().execute()
     Reference.delete().execute()
     User.delete().execute()
+
+def create_schema(schema_name):
+    """
+    Creates an isolated schema for testing purposes.
+    """
+    database_proxy.execute_sql(f'CREATE SCHEMA IF NOT EXISTS {schema_name}')
+
+def drop_schema(schema_name):
+    """
+    Drops a schema that was used for testing purposes.
+    """
+    database_proxy.execute_sql(f'DROP SCHEMA IF EXISTS {schema_name} CASCADE')


### PR DESCRIPTION
Database collisions previously occurred because all test runs shared the same testing schema ('public'). This meant that the testing database would sometimes be cleared while other testing runs were using it. 

This PR addresses this by creating a new schema for each testing run (cooperating w/ [PR #528](https://github.com/brain-score/vision/pull/528)). Between each test method, the schema is cleared, and at the end of the testing run, the schema is dropped.

Fixes [issue #516](https://github.com/brain-score/vision/issues/516) in brainscore vision.