### PR TITLE
Added support for setup.py

### DIFF
--- a/brainscore_core/plugin_management/import_plugin.py
+++ b/brainscore_core/plugin_management/import_plugin.py
@@ -64,6 +64,7 @@ class ImportPlugin:
         - If a `setup.py` file exists, it is run in the current interpreter.
         - Alternatively, if a `requirements.txt` file exists, this is done via
           `pip install` in the current interpreter.
+        - If both `setup.py` and `requirements.txt` are present, `setup.py` is installed first.
         """
         setup_file = self.plugins_dir / self.plugin_dirname / 'setup.py'
         requirements_file = self.plugins_dir / self.plugin_dirname / 'requirements.txt'

--- a/brainscore_core/plugin_management/import_plugin.py
+++ b/brainscore_core/plugin_management/import_plugin.py
@@ -61,10 +61,22 @@ class ImportPlugin:
     def install_requirements(self):
         """
         Install all the requirements of the given plugin directory.
-        This is done via `pip install` in the current interpreter.
+        - If a `setup.py` file exists, it is run in the current interpreter.
+        - Alternatively, if a `requirements.txt` file exists, this is done via
+          `pip install` in the current interpreter.
         """
+        setup_file = self.plugins_dir / self.plugin_dirname / 'setup.py'
         requirements_file = self.plugins_dir / self.plugin_dirname / 'requirements.txt'
-        if requirements_file.is_file():
+        
+        if setup_file.is_file() and requirements_file.is_file():
+            logger.debug(
+                f"Plugin {self.plugin_dirname} has both a setup script {setup_file} "
+                f"and a requirements file {requirements_file}. The setup script will be run."
+            )
+        
+        if setup_file.is_file():
+            subprocess.run(f"python {setup_file}", shell=True)
+        elif requirements_file.is_file():
             subprocess.run(f"pip install -r {requirements_file}", shell=True)
         else:
             logger.debug(f"Plugin {self.plugin_dirname} has no requirements file {requirements_file}")

--- a/brainscore_core/plugin_management/import_plugin.py
+++ b/brainscore_core/plugin_management/import_plugin.py
@@ -68,18 +68,17 @@ class ImportPlugin:
         setup_file = self.plugins_dir / self.plugin_dirname / 'setup.py'
         requirements_file = self.plugins_dir / self.plugin_dirname / 'requirements.txt'
         
-        if setup_file.is_file() and requirements_file.is_file():
+        if not setup_file.is_file() and not requirements_file.is_file():
             logger.debug(
-                f"Plugin {self.plugin_dirname} has both a setup script {setup_file} "
-                f"and a requirements file {requirements_file}. The setup script will be run."
+                f"Plugin {self.plugin_dirname} has no requirements file {requirements_file} "
+                f"or setup file {setup_file}"
             )
         
         if setup_file.is_file():
-            subprocess.run(f"python {setup_file}", shell=True)
-        elif requirements_file.is_file():
+            subprocess.run(f"pip install {self.plugins_dir / self.plugin_dirname}", shell=True)
+
+        if requirements_file.is_file():
             subprocess.run(f"pip install -r {requirements_file}", shell=True)
-        else:
-            logger.debug(f"Plugin {self.plugin_dirname} has no requirements file {requirements_file}")
 
 
 def installation_preference():

--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -2,6 +2,7 @@
 
 PLUGIN_PATH=$1
 PLUGIN_NAME=$2
+PLUGIN_SETUP_PATH=$PLUGIN_PATH/setup.py
 PLUGIN_REQUIREMENTS_PATH=$PLUGIN_PATH/requirements.txt
 PLUGIN_TEST_PATH=$PLUGIN_PATH/test.py
 SINGLE_TEST=$3
@@ -26,7 +27,9 @@ conda install pip
 if [ -f "$CONDA_ENV_PATH" ]; then
   output=$(conda env update --file $CONDA_ENV_PATH 2>&1)
 fi
-if [ -f "$PLUGIN_REQUIREMENTS_PATH" ]; then
+if [ -f "$PLUGIN_SETUP_PATH" ]; then
+  output=$(python $PLUGIN_SETUP_PATH 2>&1)
+elif [ -f "$PLUGIN_REQUIREMENTS_PATH" ]; then
   output=$(pip install -r $PLUGIN_REQUIREMENTS_PATH 2>&1)
 fi
 

--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -28,8 +28,9 @@ if [ -f "$CONDA_ENV_PATH" ]; then
   output=$(conda env update --file $CONDA_ENV_PATH 2>&1)
 fi
 if [ -f "$PLUGIN_SETUP_PATH" ]; then
-  output=$(python $PLUGIN_SETUP_PATH 2>&1)
-elif [ -f "$PLUGIN_REQUIREMENTS_PATH" ]; then
+  output=$(pip install $PLUGIN_PATH 2>&1)
+fi
+if [ -f "$PLUGIN_REQUIREMENTS_PATH" ]; then
   output=$(pip install -r $PLUGIN_REQUIREMENTS_PATH 2>&1)
 fi
 

--- a/tests/test_plugin_management/test_import_plugin.py
+++ b/tests/test_plugin_management/test_import_plugin.py
@@ -20,9 +20,9 @@ class TestImportPlugin:
 
     def teardown_method(self):
         model_registry = self._model_registry()
-        if 'dummy-model' in model_registry:
-            del model_registry['dummy-model']
-        subprocess.run('pip uninstall pyaztro --yes', shell=True)
+        for model_id in list(model_registry.keys()):
+            del model_registry[model_id]
+        subprocess.run(f'pip uninstall pyaztro pyfiglet --yes', shell=True)
         shutil.rmtree(TestImportPlugin.dummy_container_dirpath)
         if TestImportPlugin.current_dependencies_pref:  # value was set
             os.environ['BS_INSTALL_DEPENDENCIES'] = TestImportPlugin.current_dependencies_pref
@@ -51,6 +51,20 @@ class TestImportPlugin:
             import_plugin('brainscore_dummy', 'models', 'dummy-model')
         except Exception as e:
             assert "No module named 'pyaztro'" in str(e)
+
+    def test_dependency_install_from_setup_py(self):
+        os.environ['BS_INSTALL_DEPENDENCIES'] = 'yes'
+        model_registry = self._model_registry()
+        assert 'dummy-model-setup-py' not in model_registry
+        import_plugin('brainscore_dummy', 'models', 'dummy-model-setup-py')
+        assert 'dummy-model-setup-py' in model_registry
+
+    def test_dependency_install_from_setup_py_with_requirements_txt(self):
+        os.environ['BS_INSTALL_DEPENDENCIES'] = 'yes'
+        model_registry = self._model_registry()
+        assert 'dummy-model-requirements-and-setup' not in model_registry
+        import_plugin('brainscore_dummy', 'models', 'dummy-model-requirements-and-setup')
+        assert 'dummy-model-requirements-and-setup' in model_registry
 
 
 class TestRegistryPrefix:

--- a/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_requirements_and_setup/__init__.py
+++ b/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_requirements_and_setup/__init__.py
@@ -1,0 +1,5 @@
+from brainscore_dummy import model_registry
+
+from .model import DummyModel
+
+model_registry['dummy-model-requirements-and-setup'] = DummyModel

--- a/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_requirements_and_setup/model.py
+++ b/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_requirements_and_setup/model.py
@@ -1,4 +1,6 @@
+import pyfiglet
 import pyaztro
+
 
 class DummyModel:
     pass

--- a/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_requirements_and_setup/requirements.txt
+++ b/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_requirements_and_setup/requirements.txt
@@ -1,0 +1,1 @@
+pyaztro

--- a/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_requirements_and_setup/setup.py
+++ b/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_requirements_and_setup/setup.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from setuptools import setup, find_packages
+
+requirements = [
+    "pyfiglet"
+]
+
+setup(
+    name="dummy_model_requirements_and_setup",
+    packages=find_packages(exclude=['tests']),
+    include_package_data=True,
+    install_requires=requirements,
+    license="MIT license",
+    zip_safe=False,
+    keywords='brain-score template',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+    ],
+    test_suite='tests',
+)

--- a/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_requirements_and_setup/test.py
+++ b/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_requirements_and_setup/test.py
@@ -1,0 +1,2 @@
+def test_dummy():
+    assert True

--- a/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_setup_only/__init__.py
+++ b/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_setup_only/__init__.py
@@ -1,0 +1,5 @@
+from brainscore_dummy import model_registry
+
+from .model import DummyModel
+
+model_registry['dummy-model-setup-py'] = DummyModel

--- a/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_setup_only/model.py
+++ b/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_setup_only/model.py
@@ -1,4 +1,5 @@
-import pyaztro
+import pyfiglet
+
 
 class DummyModel:
     pass

--- a/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_setup_only/setup.py
+++ b/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_setup_only/setup.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from setuptools import setup, find_packages
+
+requirements = [
+    "pyfiglet"
+]
+
+setup(
+    name="dummy_model_setup_only",
+    packages=find_packages(exclude=['tests']),
+    include_package_data=True,
+    install_requires=requirements,
+    license="MIT license",
+    zip_safe=False,
+    keywords='brain-score template',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3.7',
+    ],
+    test_suite='tests',
+)

--- a/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_setup_only/test.py
+++ b/tests/test_plugin_management/test_import_plugin__brainscore_dummy/brainscore_dummy/models/dummy_model_setup_only/test.py
@@ -1,0 +1,2 @@
+def test_dummy():
+    assert True


### PR DESCRIPTION
Currently, plugins that require specific Python libraries need to specify them in a `requirements.txt` file. This PR also improves this by adding support for `setup.py` files.

One design choice is that `setup.py` precedes `requirements.txt`.