### PR TITLE
Changed public_benchmark_identifiers to avoid parent benchmarks

### DIFF
--- a/brainscore_core/plugin_management/parse_plugin_changes.py
+++ b/brainscore_core/plugin_management/parse_plugin_changes.py
@@ -198,7 +198,7 @@ def run_changed_plugin_tests(changed_files: str, domain_root: str):
             changed_plugins = plugin_info_dict["changed_plugins"][plugin_type]
             for plugin_dirname in changed_plugins:
                 plugin_dir = Path(f'{domain_root}/{plugin_type}/{plugin_dirname}')
-                tests_to_run.extend(get_test_file_paths(plugin_dir))
+                if plugin_dir.is_dir(): tests_to_run.extend(get_test_file_paths(plugin_dir))
 
     print(f"Running tests for new or modified plugins: {tests_to_run}")
     print(run_args(domain_root, tests_to_run))  # print tests to travis log

--- a/brainscore_core/submission/database.py
+++ b/brainscore_core/submission/database.py
@@ -72,8 +72,10 @@ def public_model_identifiers(domain: str) -> List[str]:
 
 
 def public_benchmark_identifiers(domain: str) -> List[str]:
-    entries = BenchmarkType.select().where(BenchmarkType.visible & (BenchmarkType.domain == domain))
-    identifiers = [entry.identifier for entry in entries]
+    entries = BenchmarkInstance.select(BenchmarkType.identifier).join(BenchmarkType).where(
+        (BenchmarkType.domain == domain) & (BenchmarkType.visible)
+    )
+    identifiers = [entry.benchmark.identifier for entry in entries]
     return identifiers
 
 

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -6,7 +6,7 @@ import botocore.exceptions
 from brainscore_core import Score, Benchmark
 from brainscore_core.submission import database_models
 from brainscore_core.submission.database import connect_db
-from brainscore_core.submission.database_models import Model, BenchmarkType, clear_schema
+from brainscore_core.submission.database_models import Model, BenchmarkType, BenchmarkInstance, clear_schema
 from brainscore_core.submission.endpoints import RunScoringEndpoint, DomainPlugins, UserManager, shorten_text, \
     resolve_models_benchmarks, resolve_models, resolve_benchmarks, make_argparser
 from tests.test_submission import init_users
@@ -111,6 +111,7 @@ class TestRunScoring:
             Model.get_or_create(name=model_id, domain="test", public=True, owner=2, submission=0)
         for benchmark_id in ["dummybenchmark1", "dummybenchmark2"]:
             BenchmarkType.get_or_create(identifier=benchmark_id, domain="test", visible=True, order=999)
+            BenchmarkInstance.get_or_create(benchmark=benchmark_id)
 
     def teardown_method(self):
         logger.info('Clean database')


### PR DESCRIPTION
The `public_benchmark_identifiers` method currently returns all identifiers in the `BenchmarkType` table, which include parent Benchmarks that are not meant to be implemented in the codebase or be added to the benchmark registry. For example, the method would return `average_vision` and `neural_vision` as benchmarks, which are not concrete benchmark instances, leading to failures when trying to score submitted models on them. Therefore, this PR changes the method to return all public identifiers from the `BenchmarkInstance` table and adds a unit test to ensure the intended behavior is captured.