### PR TITLE
brain-score uid creation fix

### DIFF
--- a/brainscore_core/submission/endpoints.py
+++ b/brainscore_core/submission/endpoints.py
@@ -44,7 +44,7 @@ class UserManager:
         return temp_pass
 
     def create_new_user(self, user_email: str):
-        signup_url = 'http://www.brain-score.org/signup'
+        signup_url = 'https://www.brain-score.org/signup'
         temp_pass = self._generate_temp_pass(length=10)
         try:
             response = requests.get(signup_url)

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -40,8 +40,8 @@ class TestUserManager:
 
     def test_create_new_user(self, requests_mock):
         # mock GET & POST responses
-        get_adapter = requests_mock.get('http://www.brain-score.org/signup', cookies={'cookie_name': 'cookie_value'})
-        post_adapter = requests_mock.post('http://www.brain-score.org/signup', status_code=200)
+        get_adapter = requests_mock.get('https://www.brain-score.org/signup', cookies={'cookie_name': 'cookie_value'})
+        post_adapter = requests_mock.post('https://www.brain-score.org/signup', status_code=200)
 
         user_manager = UserManager(self.test_database)
         user_manager.create_new_user('test@example.com')


### PR DESCRIPTION
When users were PRing to brain-score with an email not attached to a brain-score account, uids were not being created and assertion errors were occurring in the Jenkins score_plugins job.

This PR closes issue #82.