### PR TITLE
Added pip upgrade to test_plugin.sh

### DIFF
--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -24,6 +24,8 @@ eval "$(command conda 'shell.bash' 'hook' 2>/dev/null)"
 output=$(conda create -n $PLUGIN_NAME python=$PYTHON_VERSION -y 2>&1)
 conda activate $PLUGIN_NAME
 conda install pip
+pip install --upgrade pip setuptools
+
 if [ -f "$CONDA_ENV_PATH" ]; then
   output=$(conda env update --file $CONDA_ENV_PATH 2>&1)
 fi


### PR DESCRIPTION
The current `test_plugin.sh` script creates a custom conda environment for each testing plugin and uses `conda install pip` to install `pip` in that environment. However, `conda install pip` is not guaranteed to install the most recent version of `pip` and `setuptools`, which occasionally leads to the following issue when installing egg-fragmented packages:

```
Installing collected packages: UNKNOWN
  Attempting uninstall: UNKNOWN
    Found existing installation: UNKNOWN 0.0.0
    Uninstalling UNKNOWN-0.0.0:
      Successfully uninstalled UNKNOWN-0.0.0
```

This PR resolves this by making sure to update `pip` and `setuptools` prior to installing the brain-score package[ following this Stack Overflow question](https://stackoverflow.com/questions/53077360/pip-install-issue-with-egg-fragments-that-lead-to-an-unknown-installation-of-a-p).