### PR TITLE
Changing comparison to common ancestor commit

### DIFF
--- a/brainscore_core/travis/script.yml
+++ b/brainscore_core/travis/script.yml
@@ -3,7 +3,7 @@ script:
   - |
     echo 'travis_fold:start:configure'
     if [ ! -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then 
-      CHANGED_FILES=$( git fetch origin pull/$TRAVIS_PULL_REQUEST/head:pr_branch && echo $(git diff --name-only pr_branch $TRAVIS_BRANCH -C $TRAVIS_BUILD_DIR) | tr '\n' ' ' ) &&
+      CHANGED_FILES=$( git fetch origin pull/$TRAVIS_PULL_REQUEST/head:pr_branch && echo $(git diff --name-only $TRAVIS_BRANCH...pr_branch -C $TRAVIS_BUILD_DIR) | tr '\n' ' ' ) &&
       TESTING_NEEDED=$( python -c "from brainscore_core.plugin_management.parse_plugin_changes import get_testing_info; get_testing_info(\"${CHANGED_FILES}\", \"brainscore_${DOMAIN}\")" ) && 
       read MODIFIES_PLUGIN PLUGIN_ONLY <<< $TESTING_NEEDED && echo MODIFIES_PLUGIN: $MODIFIES_PLUGIN && echo PLUGIN_ONLY: $PLUGIN_ONLY; 
     fi


### PR DESCRIPTION
Goes with vision [PR #664](https://github.com/brain-score/vision/pull/664).

Travis tests do not yet account for autosubmission PRs that have fallen out of date with the `main`/`master` branch. When the target branch (`main`) is ahead of the incoming submission branch, the changed files in `main` are counted as part of "parse_plugin_changes", and consequently "plugin_only" is ruled `False` which triggers a full test run. This is causing a timeout in the Travis tests. 

This PR is a minimal solution that changes the git diff to compare to where the submission branched off of `main`, thereby only considering the changes directly from the submission. This removes the effect on "plugin_only" rulings and allows plugins to resume testing without running the full repo-wide suite.