### PR TITLE
Dk/detect failed tests

### DIFF
--- a/brainscore_core/plugin_management/test_plugins.py
+++ b/brainscore_core/plugin_management/test_plugins.py
@@ -157,10 +157,3 @@ def run_args(root_directory: Union[Path, str], test_files: Union[None, List[str]
     plugins_with_errors = {k: v for k, v in results.items() if (v != 0) and (v != 5)}
     num_plugins_failed = len(plugins_with_errors)
     assert num_plugins_failed == 0, f"\n{num_plugins_failed} plugin tests failed\n{plugins_with_errors}"
-
-
-
-# Check for:
-#     rug_args
-#     run_all_tests
-#     run_specified_tests

--- a/brainscore_core/plugin_management/test_plugins.py
+++ b/brainscore_core/plugin_management/test_plugins.py
@@ -28,7 +28,7 @@ class PluginTestRunner(EnvironmentManager):
     python brainscore_core/plugin_management/test_plugins.py
     """
 
-    def __init__(self, plugin_directory: Path, results: Dict, test: Union[bool, str] = False):
+    def __init__(self, plugin_directory: Path, test: Union[bool, str] = False):
         super(PluginTestRunner, self).__init__()
 
         self.plugin_directory = plugin_directory
@@ -38,14 +38,15 @@ class PluginTestRunner(EnvironmentManager):
         self.generic_plugin_test = self._resolve_generic_plugin_test()
         self.env_name = self.plugin_name
         self.test = test if test else False
-        self.results = results
+        self.returncode = None
         self.script_path = Path(__file__).parent / 'test_plugin.sh'
         assert self.script_path.is_file(), f"bash file {self.script_path} does not exist"
 
-    def __call__(self):
+    def __call__(self) -> Dict:
         self.validate_plugin()
         self.run_tests()
         self.teardown()
+        return self.returncode
 
     def validate_plugin(self):
         self._validate_test_files()
@@ -93,7 +94,7 @@ class PluginTestRunner(EnvironmentManager):
         completed_process = self.run_in_env(run_command)
         check.equal(completed_process.returncode, 0)  # use check to register any errors, but let tests continue
 
-        self.results[self.plugin_name] = completed_process.returncode
+        self.result = completed_process.returncode
 
         if "TRAVIS" in os.environ:
             print(f"travis_fold:end:{self.plugin_directory}")
@@ -109,25 +110,31 @@ class PluginTestRunner(EnvironmentManager):
         return generic_plugin_test
 
 
-def run_specified_tests(root_directory: Path, test_file: str, results: Dict, test: str):
+def run_specified_tests(root_directory: Path, test_file: str, test: str) -> Dict:
     """ Runs either a single test or all tests in the specified test file """
+
+    results = {}
     plugin_type, plugin_dirname, filename = test_file.split('/')[-3:]
     plugin = root_directory / plugin_type / plugin_dirname
     assert re.match(RECOGNIZED_TEST_FILES, filename), \
         f"Test file {filename} not recognized as test file, must match '{RECOGNIZED_TEST_FILES}'."
     assert plugin_type in PLUGIN_TYPES, "Filepath not recognized as plugin test file."
-    plugin_test_runner = PluginTestRunner(plugin, results, test=test)
-    plugin_test_runner()
+    plugin_test_runner = PluginTestRunner(plugin, test=test)
+    results[plugin_test_runner.plugin_name] = plugin_test_runner()
+
+    return results
 
 
-def run_all_tests(root_directory: Path, results: Dict):
+def run_all_tests(root_directory: Path) -> Dict:
     """ Runs tests for all plugins """
+    results = {}
     for plugin_type in PLUGIN_TYPES:
         plugins_dir = root_directory / plugin_type
         for plugin in plugins_dir.glob('[!._]*'):
             if plugin.is_dir():
-                plugin_test_runner = PluginTestRunner(plugin, results)
-                plugin_test_runner()
+                plugin_test_runner = PluginTestRunner(plugin)
+                results[plugin_test_runner.plugin_name] = plugin_test_runner()
+    return results
 
 
 def run_args(root_directory: Union[Path, str], test_files: Union[None, List[str]] = None,
@@ -141,12 +148,19 @@ def run_args(root_directory: Union[Path, str], test_files: Union[None, List[str]
     """
     results = {}
     if not test_files:
-        run_all_tests(root_directory=Path(root_directory), results=results)
+        results = run_all_tests(root_directory=Path(root_directory))
     else:
         for test_file in test_files:
             assert Path(test_file).exists()
-            run_specified_tests(root_directory=Path(root_directory), test_file=test_file, results=results, test=test)
+            results = run_specified_tests(root_directory=Path(root_directory), test_file=test_file, test=test)
 
     plugins_with_errors = {k: v for k, v in results.items() if (v != 0) and (v != 5)}
     num_plugins_failed = len(plugins_with_errors)
     assert num_plugins_failed == 0, f"\n{num_plugins_failed} plugin tests failed\n{plugins_with_errors}"
+
+
+
+# Check for:
+#     rug_args
+#     run_all_tests
+#     run_specified_tests

--- a/tests/test_plugin_management/test_test_plugins.py
+++ b/tests/test_plugin_management/test_test_plugins.py
@@ -56,11 +56,11 @@ class TestPluginTestRunner:
         dummy_plugin_path = self.library_path / 'brainscore_dummy' / 'plugintype' / 'dummy_plugin'
         plugin_test_runner = PluginTestRunner(dummy_plugin_path, {})
         plugin_test_runner.run_tests()
-        assert plugin_test_runner.results[plugin_test_runner.plugin_name] == 0
+        assert plugin_test_runner.returncode == 0
 
     @pytest.mark.travis_slow
     def test_run_tests_with_r(self):
         r_plugin_path = self.library_path / 'brainscore_dummy' / 'plugintype' / 'r_plugin'
         plugin_test_runner = PluginTestRunner(r_plugin_path, {})
         plugin_test_runner.run_tests()
-        assert plugin_test_runner.results[plugin_test_runner.plugin_name] == 0
+        assert plugin_test_runner.returncode == 0


### PR DESCRIPTION
Failed plugin tests were not being detected because of an issue with how failures were being stored. This PR should fix that storage issue.