### PR TITLE
Add xml writing for generic plugin tests

### DIFF
--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -40,7 +40,7 @@ output=$(python -m pip install -e ".[test]" 2>&1) # install library requirements
 
 ### RUN GENERIC TESTING
 if [ "$GENERIC_TEST_PATH" != False ]; then
-  pytest -m "$PYTEST_SETTINGS" "-vv" $GENERIC_TEST_PATH "--plugin_directory" $PLUGIN_PATH "--log-cli-level=INFO"
+  pytest -m "$PYTEST_SETTINGS" "-vv" $GENERIC_TEST_PATH "--plugin_directory" $PLUGIN_PATH "--log-cli-level=INFO" "--junitxml" $XML_FILE
 fi
 
 ### RUN TESTING


### PR DESCRIPTION
Addresses bug brought up in [Issue 735](https://github.com/orgs/brain-score/projects/3/views/1?pane=issue&itemId=58408553) in the Vision repo. This will capture the generic plugin tests in XML format so that they can be merged with the non-generic plugin tests at the end of our builds.