### PR TITLE
test only subset of models when all used to be tested

### DIFF
--- a/brainscore_core/plugin_management/parse_plugin_changes.py
+++ b/brainscore_core/plugin_management/parse_plugin_changes.py
@@ -198,7 +198,7 @@ def run_changed_plugin_tests(changed_files: str, domain_root: str):
             plugin_type_dir = Path(f'{domain_root}/{plugin_type}')
             for plugin_dir in plugin_type_dir.iterdir():
                 if plugin_dir.is_dir():
-                    if plugin_type == 'models' and plugin_dir.name not in MODEL_SUBSET:  # run subset of models to decrease test time
+                    if plugin_type_dir == 'brainscore_vision/models' and plugin_dir.name not in MODEL_SUBSET:  # run subset of models to decrease test time
                         continue
                     tests_to_run.extend(get_test_file_paths(plugin_dir))
         else:

--- a/brainscore_core/plugin_management/parse_plugin_changes.py
+++ b/brainscore_core/plugin_management/parse_plugin_changes.py
@@ -4,14 +4,11 @@ from pathlib import Path
 import re
 from typing import List, Tuple, Dict
 
-from .test_plugins import run_args
+from .test_plugins import run_args, MODEL_SUBSET
 
 PLUGIN_DIRS = ['models', 'benchmarks', 'data', 'metrics']
 SPECIAL_PLUGIN_FILES = ['brainscore_vision/model_interface.py', 'brainscore_language/artificial_subject.py']
-MODEL_SUBSET = ['hmax', 'alexnet', 'CORnet-S', 'resnet-50-robust', 'voneresnet-50-non_stochastic', 
-                'resnet18-local_aggregation', 'grcnn_robust_v1', 'custom_model_cv_18_dagger_408', 
-                'ViT_L_32_imagenet1k', 'mobilenet_v2_1.4_224', 'pixels', 'cvt_cvt-w24-384-in22k_finetuned-in1k_4', 
-                'resnext101_32x8d_wsl', 'effnetb1_cutmixpatch_augmix_robust32_avge4e7_manylayers_324x288']
+
 
 
 def separate_plugin_files(files: List[str]) -> Tuple[List[str], List[str], List[str]]:

--- a/brainscore_core/plugin_management/parse_plugin_changes.py
+++ b/brainscore_core/plugin_management/parse_plugin_changes.py
@@ -8,6 +8,10 @@ from .test_plugins import run_args
 
 PLUGIN_DIRS = ['models', 'benchmarks', 'data', 'metrics']
 SPECIAL_PLUGIN_FILES = ['brainscore_vision/model_interface.py', 'brainscore_language/artificial_subject.py']
+MODEL_SUBSET = ['hmax', 'alexnet', 'CORnet-S', 'resnet-50-robust', 'voneresnet-50-non_stochastic', 
+                'resnet18-local_aggregation', 'grcnn_robust_v1', 'custom_model_cv_18_dagger_408', 
+                'ViT_L_32_imagenet1k', 'mobilenet_v2_1.4_224', 'pixels', 'cvt_cvt-w24-384-in22k_finetuned-in1k_4', 
+                'resnext101_32x8d_wsl', 'effnetb1_cutmixpatch_augmix_robust32_avge4e7_manylayers_324x288']
 
 
 def separate_plugin_files(files: List[str]) -> Tuple[List[str], List[str], List[str]]:
@@ -193,7 +197,10 @@ def run_changed_plugin_tests(changed_files: str, domain_root: str):
         if plugin_type in plugin_info_dict["test_all_plugins"]:
             plugin_type_dir = Path(f'{domain_root}/{plugin_type}')
             for plugin_dir in plugin_type_dir.iterdir():
-                if plugin_dir.is_dir(): tests_to_run.extend(get_test_file_paths(plugin_dir))
+                if plugin_dir.is_dir():
+                    if plugin_type == 'models' and plugin_dir.name not in MODEL_SUBSET:  # run subset of models to decrease test time
+                        continue
+                    tests_to_run.extend(get_test_file_paths(plugin_dir))
         else:
             changed_plugins = plugin_info_dict["changed_plugins"][plugin_type]
             for plugin_dirname in changed_plugins:

--- a/brainscore_core/plugin_management/test_plugins.py
+++ b/brainscore_core/plugin_management/test_plugins.py
@@ -133,7 +133,7 @@ def run_all_tests(root_directory: Path) -> Dict:
         plugins_dir = root_directory / plugin_type
         for plugin in plugins_dir.glob('[!._]*'):
             if plugin.is_dir():
-                if plugin_type == 'models' and plugin.name not in MODEL_SUBSET:  # run subset of models to decrease test time
+                if plugins_dir == 'brainscore_vision/models' and plugin.name not in MODEL_SUBSET:  # run subset of models to decrease test time
                     continue
                 plugin_test_runner = PluginTestRunner(plugin)
                 plugin_test_runner()

--- a/brainscore_core/plugin_management/test_plugins.py
+++ b/brainscore_core/plugin_management/test_plugins.py
@@ -7,6 +7,7 @@ import pytest_check as check
 import yaml
 
 from .environment_manager import EnvironmentManager
+from .parse_plugin_changes import MODEL_SUBSET
 
 PLUGIN_TYPES = ['benchmarks', 'data', 'metrics', 'models']
 RECOGNIZED_TEST_FILES = r'test.*\.py'
@@ -132,6 +133,8 @@ def run_all_tests(root_directory: Path) -> Dict:
         plugins_dir = root_directory / plugin_type
         for plugin in plugins_dir.glob('[!._]*'):
             if plugin.is_dir():
+                if plugin_type == 'models' and plugin.name not in MODEL_SUBSET:  # run subset of models to decrease test time
+                    continue
                 plugin_test_runner = PluginTestRunner(plugin)
                 plugin_test_runner()
                 results[plugin_test_runner.plugin_name] = plugin_test_runner.returncode

--- a/brainscore_core/plugin_management/test_plugins.py
+++ b/brainscore_core/plugin_management/test_plugins.py
@@ -7,11 +7,14 @@ import pytest_check as check
 import yaml
 
 from .environment_manager import EnvironmentManager
-from .parse_plugin_changes import MODEL_SUBSET
 
 PLUGIN_TYPES = ['benchmarks', 'data', 'metrics', 'models']
 RECOGNIZED_TEST_FILES = r'test.*\.py'
 GENERIC_PLUGIN_TEST_FILENAME = "generic_plugin_tests.py"
+MODEL_SUBSET = ['hmax', 'alexnet', 'CORnet-S', 'resnet-50-robust', 'voneresnet-50-non_stochastic', 
+                'resnet18-local_aggregation', 'grcnn_robust_v1', 'custom_model_cv_18_dagger_408', 
+                'ViT_L_32_imagenet1k', 'mobilenet_v2_1.4_224', 'pixels', 'cvt_cvt-w24-384-in22k_finetuned-in1k_4', 
+                'resnext101_32x8d_wsl', 'effnetb1_cutmixpatch_augmix_robust32_avge4e7_manylayers_324x288']
 
 
 class PluginTestRunner(EnvironmentManager):


### PR DESCRIPTION
Previously, when certain files were altered (such as files within the [model_helpers](https://github.com/brain-score/vision/tree/master/brainscore_vision/model_helpers) directory of brainscore_vision), tests were run on all models present in the brainscore_vision repository. This change should ensure that only the following subset of models are run:

- hmax
- alexnet
- CORnet-S
- resnet-50-robust
- voneresnet-50-non_stochastic
- resnet18-local_aggregation
- grcnn_robust_v1
- custom_model_cv_18_dagger_408
- ViT_L_32_imagenet1k
- mobilenet_v2_1.4_224
- pixels
- cvt_cvt-w24-384-in22k_finetuned-in1k_4
- resnext101_32x8d_wsl
- effnetb1_cutmixpatch_augmix_robust32_avge4e7_manylayers_324x288