### PR TITLE
clone overarching env

### DIFF
--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -22,15 +22,14 @@ echo "$PLUGIN_NAME ($PLUGIN_PATH)"
 echo "Setting up conda environment..."
 echo "Python version: $PYTHON_VERSION"
 eval "$(command conda 'shell.bash' 'hook' 2>/dev/null)"
-output=$(conda create -n $PLUGIN_NAME python=$PYTHON_VERSION -y 2>&1)
+current_env=$CONDA_DEFAULT_ENV
+output=$(conda create -n $PLUGIN_NAME --clone $current_env -y 2>&1)
 echo "$output"
 if [ $? -ne 0 ]; then
   echo "Failed to create environment: $output"
   exit 1
 fi
 conda activate $PLUGIN_NAME
-conda install pip
-pip install --upgrade pip setuptools
 
 if [ -f "$CONDA_ENV_PATH" ]; then
   output=$(conda env update --file $CONDA_ENV_PATH 2>&1)
@@ -41,8 +40,6 @@ fi
 if [ -f "$PLUGIN_REQUIREMENTS_PATH" ]; then
   output=$(pip install -r $PLUGIN_REQUIREMENTS_PATH 2>&1)
 fi
-
-output=$(python -m pip install -e ".[test]" 2>&1) # install library requirements
 
 ### RUN GENERIC TESTING
 if [ "$GENERIC_TEST_PATH" != False ]; then


### PR DESCRIPTION
Previously, a new environment was created for each plugin tested, and pip install was used to bring back all of the project dependencies. This method will instead utilize the already created env and clone it, while pulling from the conda cache.