### PR TITLE
Changing install inside conda env to have retries

### DIFF
--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -34,13 +34,13 @@ if [ -f "$CONDA_ENV_PATH" ]; then
   conda env update --file $CONDA_ENV_PATH 2>&1
 fi
 if [ -f "$PLUGIN_SETUP_PATH" ]; then
-  pip install $PLUGIN_PATH 2>&1
+  pip install $PLUGIN_PATH --default-timeout=600 --retries=5 2>&1
 fi
 if [ -f "$PLUGIN_REQUIREMENTS_PATH" ]; then
-  pip install -r $PLUGIN_REQUIREMENTS_PATH 2>&1
+  pip install -r $PLUGIN_REQUIREMENTS_PATH --default-timeout=600 --retries=5 2>&1
 fi
 
-output=$(python -m pip install -e ".[test]" 2>&1) # install library requirements
+output=$(python -m pip install -e ".[test]" --default-timeout=600 --retries=5 2>&1) # install library requirements
 output=$(pip install junitparser 2>&1)
 
 ### RUN GENERIC TESTING

--- a/brainscore_core/plugin_management/test_plugin.sh
+++ b/brainscore_core/plugin_management/test_plugin.sh
@@ -30,6 +30,8 @@ conda activate $PLUGIN_NAME
 conda install pip
 pip install --upgrade pip setuptools
 
+output=$(python -m pip install -e ".[test]" --default-timeout=600 --retries=5 2>&1) # install library requirements
+
 if [ -f "$CONDA_ENV_PATH" ]; then
   conda env update --file $CONDA_ENV_PATH 2>&1
 fi
@@ -40,7 +42,6 @@ if [ -f "$PLUGIN_REQUIREMENTS_PATH" ]; then
   pip install -r $PLUGIN_REQUIREMENTS_PATH --default-timeout=600 --retries=5 2>&1
 fi
 
-output=$(python -m pip install -e ".[test]" --default-timeout=600 --retries=5 2>&1) # install library requirements
 output=$(pip install junitparser 2>&1)
 
 ### RUN GENERIC TESTING


### PR DESCRIPTION
Adding retries to this install should minimize our issues with torch install

Moving project pip install to top of script should reduce the likelihood of version mismatch

See vision PR [#893](https://github.com/brain-score/vision/pull/893) for successful test