### PR TITLE
set encoding to utf-8 when opening plugin init files

### DIFF
--- a/brainscore_core/plugin_management/import_plugin.py
+++ b/brainscore_core/plugin_management/import_plugin.py
@@ -46,7 +46,10 @@ class ImportPlugin:
                 continue
             plugin_dirpath = self.plugins_dir / plugin_dirname
             init_file = plugin_dirpath / "__init__.py"
-            with open(init_file) as f:
+            if not init_file.is_file():
+                logger.warning(f"No __init__.py in {plugin_dirpath}")
+                continue
+            with open(init_file, encoding='utf-8') as f:
                 plugin_registrations = [line for line in f if f"{self.registry_name}['{self.identifier}']"
                                         in line.replace('\"', '\'')]
                 if len(plugin_registrations) > 0:


### PR DESCRIPTION
following report from Marin Dujmovic:
> on a couple of different Windwos systems is the error [...] I was running into a couple of weeks ago. I guess for some reason it ends up forcing cp1252 instead of utf8 and it throws up this error whenever a plugin is being loaded (metric, benchmark etc.).