### PR TITLE
Changing syntax of dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ test = [
 
 [build-system]
 requires = [
-    "setuptools>=65.*",
+    "setuptools>=65",
     "wheel"
 ]
 


### PR DESCRIPTION
In PR #123 readthedocs is throwing the following error:
```sh
× Can not process file:///home/docs/checkouts/readthedocs.org/user_builds/brain-score-core/checkouts/123 (from -r docs/requirements.txt (line 1))
╰─> This package has an invalid `build-system.requires` key in pyproject.toml.
    It contains an invalid requirement: 'setuptools>=65.*'
```

Hoping that changing the syntax from `'setuptools>=65.*'` to `'setuptools>=65'` fixes the issue.