### PR TITLE
Changing fetch to compare to remote branch

### DIFF
--- a/brainscore_core/travis/script.yml
+++ b/brainscore_core/travis/script.yml
@@ -3,7 +3,7 @@ script:
   - |
     echo 'travis_fold:start:configure'
     if [ ! -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then 
-      CHANGED_FILES=$( git fetch origin pull/$TRAVIS_PULL_REQUEST/head:pr_branch && echo $(git diff --name-only $TRAVIS_BRANCH...pr_branch -C $TRAVIS_BUILD_DIR) | tr '\n' ' ' ) &&
+      CHANGED_FILES=$( git fetch origin pull/$TRAVIS_PULL_REQUEST/head:pr_branch && echo $(git diff --name-only origin/$TRAVIS_BRANCH...pr_branch) | tr '\n' ' ' ) &&
       TESTING_NEEDED=$( python -c "from brainscore_core.plugin_management.parse_plugin_changes import get_testing_info; get_testing_info(\"${CHANGED_FILES}\", \"brainscore_${DOMAIN}\")" ) && 
       read MODIFIES_PLUGIN PLUGIN_ONLY <<< $TESTING_NEEDED && echo MODIFIES_PLUGIN: $MODIFIES_PLUGIN && echo PLUGIN_ONLY: $PLUGIN_ONLY; 
     fi


### PR DESCRIPTION
Git fetch in travis does not grab the latest changes for the comparison branch, which leads to issues including not having a record of the target branch (see [here](https://app.travis-ci.com/github/brain-score/vision/jobs/624708145#L4011:~:text=*%20%5Bnew%20ref%5D%20%20%20%20%20%20%20%20%20refs,command%3E%20%5B%3Crevision%3E...%5D%20%2D%2D%20%5B%3Cfile%3E...%5D%27))