### PR TITLE
Point to PyPi package for brainio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.11"
 dependencies = [
     "tqdm",
     "numpy>=1.21,<2.0",
-    "brainscore-brainio@git+https://github.com/brain-score/brainio.git@main",
+    "brainscore-brainio",
     "psycopg2-binary", # postgres driver
     # submission
     "fire",


### PR DESCRIPTION
Now that brainio is on pypi, the pyproject needs to be updated so that core can also be pushed to PyPi.