### PR TITLE
Skip deleted plugin files

### DIFF
--- a/brainscore_core/plugin_management/parse_plugin_changes.py
+++ b/brainscore_core/plugin_management/parse_plugin_changes.py
@@ -94,6 +94,9 @@ def get_plugin_ids(plugin_type: str, new_plugin_dirs: List[str], domain_root: st
 
     for plugin_dirname in new_plugin_dirs:
         init_file = Path(f'{domain_root}/{plugin_type}/{plugin_dirname}/__init__.py')
+        if not init_file.exists():
+            print(f"Warning: {init_file} does not exist. Skipping.")
+            continue
         with open(init_file) as f:
             registry_name = plugin_type.strip(
                 's') + '_registry'  # remove plural and determine variable name, e.g. "models" -> "model_registry"


### PR DESCRIPTION
Currently, deleted files trigger a score plugins run, but a silent error is occurring that stops scoring if the deleted files are present with the addition of a new plugin. This PR should handle gracefully.