### PR TITLE
Fix RTD error

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,3 +8,6 @@ build:
 python:
    install:
       - requirements: docs/requirements.txt
+      
+sphinx:
+  configuration: docs/source/conf.py


### PR DESCRIPTION
Missing Sphinx configuration key The sphinx.configuration key is missing. This key is now required, see our [blog post](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/) for more information.

Added the conf file and now it works.