### PR TITLE
submission: stop logging secret names at INFO

### DIFF
--- a/brainscore_core/submission/endpoints.py
+++ b/brainscore_core/submission/endpoints.py
@@ -51,7 +51,7 @@ class UserManager:
     """
 
     def __init__(self, db_secret: str):
-        logger.info(f"Connecting to db using secret '{db_secret}")
+        logger.debug("Connecting to db")
         connect_db(db_secret=db_secret)
 
     def _generate_temp_pass(self, length: int) -> str:
@@ -132,7 +132,7 @@ class MetadataEndpoint:
 
     def __init__(self, domain_plugins: DomainPlugins, db_secret: str):
         self.domain_plugins = domain_plugins
-        logger.info(f"Connecting to db using secret '{db_secret}'")
+        logger.debug("Connecting to db")
         connect_db(db_secret=db_secret)
 
     def process_metadata(self, plugin_dir: str, plugin_type: str, domain: str = None) -> dict:
@@ -206,7 +206,7 @@ class RunScoringEndpoint:
     def __init__(self, domain_plugins: DomainPlugins, db_secret: str):
         self.domain_plugins = domain_plugins
         self._db_secret = db_secret
-        logger.info(f"Connecting to db using secret '{db_secret}'")
+        logger.debug("Connecting to db")
         connect_db(db_secret=db_secret)
 
     def _is_production(self) -> bool:

--- a/brainscore_core/submission/utils.py
+++ b/brainscore_core/submission/utils.py
@@ -24,7 +24,7 @@ class UniqueKeyDict(dict):
 
 def get_secret(secret_name: str, region_name: str = 'us-east-2') -> str:
     session = boto3.session.Session()
-    _logger.info("Fetch secret from secret manager")
+    _logger.debug("Fetch secret from secret manager")
     client = session.client(
         service_name='secretsmanager',
         region_name=region_name,
@@ -32,12 +32,8 @@ def get_secret(secret_name: str, region_name: str = 'us-east-2') -> str:
     secret_value_response = client.get_secret_value(
         SecretId=secret_name
     )
-    # Secrets Manager decrypts the secret value using the associated KMS CMK
-    # Depending on whether the secret was a string or binary, only one of these fields will be populated
-    _logger.info(f'Secret {secret_name} successfully fetched')
+    _logger.debug('Secret successfully fetched')
     if 'SecretString' in secret_value_response:
-        _logger.info("Inside string response...")
         return secret_value_response['SecretString']
     else:
-        _logger.info("Inside binary response...")
         return secret_value_response['SecretBinary']


### PR DESCRIPTION
Container scoring logs were printing the AWS secret name on every db connect (3 call sites in endpoints.py + 3 lines in utils.get_secret). The name isn't the value, but exposing it leaks deployment topology (prod vs staging) to anyone with build-log access. Demote to DEBUG everywhere.